### PR TITLE
feat: Add MCP Registry metadata for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "claude-code-memory",
-  "version": "1.0.1",
+  "version": "1.0.2",
+  "mcpName": "io.github.yuvalsuede/memory-mcp",
   "description": "Persistent memory for Claude Code — never lose context between sessions",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.yuvalsuede/memory-mcp",
+  "description": "Persistent memory for Claude Code — never lose context between sessions. Silent auto-capture via hooks, Haiku-powered extraction, smart dedup, and mid-session recall.",
+  "repository": {
+    "url": "https://github.com/yuvalsuede/memory-mcp",
+    "source": "github"
+  },
+  "version": "1.0.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "claude-code-memory",
+      "version": "1.0.2",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `mcpName` field to `package.json` for MCP Registry namespace verification
- Adds `server.json` file with registry metadata
- Bumps version to 1.0.2

## Next steps after merge
1. Run `npm publish` to publish v1.0.2 with the `mcpName` field
2. Install `mcp-publisher`: `brew install mcp-publisher` or download from https://github.com/modelcontextprotocol/registry/releases
3. Authenticate: `mcp-publisher login`
4. Publish to registry: `mcp-publisher publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)